### PR TITLE
Tensorflow requiere cuda 10.0, no 10.1

### DIFF
--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -14,8 +14,8 @@ dependencies:
    - ipykernel
    - tqdm
    - nltk
-   - sklearn
-   - cudatoolkit
+   - scikit-learn
+   - cudatoolkit=10.0
    - cudnn
    - pip:
      - tf-nightly-gpu-2.0-preview


### PR DESCRIPTION
Tensorflow requiere cuda 10.0 y no funciona con 10.1. Para probarlo, con su ambiente ejecuten:
python -c "import tensorflow as tf; tf.test.is_gpu_available()"
Eso regres "False", pues le faltan varias bibliotecas, y de hecho tensorflow corre en la CPU.

El problema es que conda instala cuda 10.1, y tensorflow espera 10.0
https://www.tensorflow.org/install/gpu

El otro problema es que se llama scikit-learn, no sklearn, en los repositorios de conda:
https://scikit-learn.org/stable/install.html